### PR TITLE
Intercept Groovy properties

### DIFF
--- a/new-app/src/main/java/groovy/runtime/metaclass/org/gradle/demo/api/evolution/ServerMetaClass.java
+++ b/new-app/src/main/java/groovy/runtime/metaclass/org/gradle/demo/api/evolution/ServerMetaClass.java
@@ -1,0 +1,27 @@
+package groovy.runtime.metaclass.org.gradle.demo.api.evolution;
+
+import groovy.lang.DelegatingMetaClass;
+import groovy.lang.MetaClass;
+import org.gradle.demo.api.evolution.Server;
+
+// Loaded by groovy runtime automatically
+@SuppressWarnings("unused")
+public class ServerMetaClass extends DelegatingMetaClass {
+    public ServerMetaClass(MetaClass delegate) {
+        super(delegate);
+    }
+
+    public ServerMetaClass(Class theClass) {
+        super(theClass);
+    }
+
+    @Override
+    public void setProperty(Object object, String property, Object newValue) {
+        Server server = (Server) object;
+        if ("testProperty".equals(property)) {
+            server.getTestProperty().set((String) newValue);
+            return;
+        }
+        super.setProperty(object, property, newValue);
+    }
+}

--- a/new-app/src/main/java/org/gradle/demo/api/evolution/Instrumented.java
+++ b/new-app/src/main/java/org/gradle/demo/api/evolution/Instrumented.java
@@ -14,6 +14,7 @@ public class Instrumented {
                     array.array[callSite.getIndex()] = new SetTestPropertiesCallSite(callSite);
                     break;
                 case "getTestProperty":
+                case "testProperty":
                     array.array[callSite.getIndex()] = new GetTestPropertiesCallSite(callSite);
                     break;
             }
@@ -46,6 +47,14 @@ public class Instrumented {
                 return ((Server) receiver).getTestProperty().get();
             }
             return super.call(receiver);
+        }
+
+        @Override
+        public Object callGetProperty(Object receiver) throws Throwable {
+            if (receiver instanceof Server) {
+                return ((Server) receiver).getTestProperty().get();
+            }
+            return super.callGetProperty(receiver);
         }
     }
 }

--- a/old-client/src/main/groovy/org/gradle/demo/api/evolution/DynamicGroovyClient.groovy
+++ b/old-client/src/main/groovy/org/gradle/demo/api/evolution/DynamicGroovyClient.groovy
@@ -5,6 +5,9 @@ class DynamicGroovyClient {
         def server = new Server()
         doSet(server)
         println doGet(server)
+
+        doSetAsProperty(server)
+        println doGetAsProperty(server)
     }
 
     private static void doSet(Object server) {
@@ -12,5 +15,13 @@ class DynamicGroovyClient {
     }
     private static Object doGet(Object server) {
         return server.getTestProperty()
+    }
+
+    private static Object doGetAsProperty(Object server) {
+        return server.testProperty
+    }
+
+    private static Object doSetAsProperty(Object server) {
+        return server.testProperty = "Лайош"
     }
 }


### PR DESCRIPTION
Property reads are simple as they go through the same CallSiteArray, we
just add another interceptor that redirects the read to the new
property.

Writes are completely different beasts because there is no CallSite.
Instead lookup goes through metaclass without the middleman. So we have
to intercept at metaclass level as well. Thankfully, a metaclass with
a carefully crafted name can be picked up by Groovy runtime
automagically[1].

We might consider switching to metaclasses for other things to make
things uniform.

For Gradle these metaclasses will have to be generated for classes that
we want to backport at some point.

  [1]: https://docs.groovy-lang.org/latest/html/documentation/core-metaprogramming.html#_magic_package